### PR TITLE
Import Directive from docutils.parsers.rst

### DIFF
--- a/src/sphinxjp/themes/impressjs/directives.py
+++ b/src/sphinxjp/themes/impressjs/directives.py
@@ -12,7 +12,7 @@
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.roles import set_classes
 from docutils import nodes
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 __docformat__ = 'reStructuredText'
 


### PR DESCRIPTION
sphinx.util.compat was removed in sphinx 1.7. Import Directive from docutils.parsers.rst instead, as recommended in the [sphinx changelog](https://github.com/sphinx-doc/sphinx/blob/master/CHANGES).